### PR TITLE
fix include

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,12 @@ module.exports = function () {
 
     //转化所有子模板为require
     var requires = output.requires.map(function (req) {
-        return "require('" + path.relative(path.dirname(output.sourceFile), req + extname).replace(/\\/g, '/') + "');";
+        var tmpPath = path.relative(path.dirname(output.sourceFile), req + extname).replace(/\\/g, '/');
+
+        //如果include的文件是当前目录下的文件,需要加"./"前缀,否则无法找到该文件,你懂的
+        tmpPath.indexOf("/") == -1 && (tmpPath = "./" + tmpPath);
+
+        return "require('" + tmpPath + "');";
     }).join('');
 
     clearTimeout(timer);


### PR DESCRIPTION
解决在模版中嵌套子模板，且该模板和嵌套模板在同一个目录下，webpack编译报错问题。

该问题主要是生成的路径为require("childTpl.html");
这样webpack会去node_modules下面去找，因此找不到该模板。
修改以后生成的路径变为require("./childTpl.html"), 便不再有问题。

看到有人讨论了这个问题可是模块还是没有更新，希望尽快能更新。
