### PR TITLE
修复runtime.js的bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmodjs-loader",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "repository": "https://github.com/xosuperpig/tmodjs-loader.git",
   "main": "index.js",

--- a/runtime.js
+++ b/runtime.js
@@ -58,7 +58,7 @@
 		}
 	}
 
-	var j = a.cache = {}, k = this.String, l = {
+	var j = a.cache = {}, k = String, l = {
 		"<": "&#60;",
 		">": "&#62;",
 		'"': "&#34;",


### PR DESCRIPTION
61行

``` javascript
k = this.String,
```

被webpack打包以后，this 是 undefined，改为

``` javascript
k = String,
```
